### PR TITLE
feat: add GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,11 +25,6 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libglib2.0-dev libdbus-1-dev libxkbcommon-dev
-
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ name: Build Module
 on:
   push:
     branches: [main]
+    paths-ignore: ["*.md", "*.png", "*.jpg"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,11 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-        with:
-          override: true
-          components: rustfmt, clippy
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libglib2.0-dev libgtk-3-dev
 
       - name: Cache cargo registry
         uses: actions/cache@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config libgtk-3-dev \
-          libglib2.0-dev libdbus-1-dev libxkbcommon-dev
+          sudo apt-get install -y libgtk-3-dev libglib2.0-dev libdbus-1-dev libxkbcommon-dev
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -48,5 +47,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: niri_window_buttons
-          path: /target/release
-          retention days: 45
+          path: /home/runner/work/niri_window_buttons/niri_window_buttons/target/release
+          retention-days: 45

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+---
+name: Build Module
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Build Module"]
+    types:
+      - completed
+    branches: [main]
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  build-module:
+    name: Build Module
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libgtk-3-dev libglib2.0-dev
+
+      - name: Build with cargo
+        run: cargo build --release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ name: Build Module
 on:
   push:
     branches: [main]
-    paths-ignore: ["*.md", "*.png", "*.jpg"]
+    paths-ignore: ["**/*.md", "**/*.png", "**/*.jpg"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.87
+          toolchain: stable
           override: true
           components: rustfmt, clippy
 
@@ -47,5 +47,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: niri_window_buttons
-          path: /home/runner/work/niri_window_buttons/niri_window_buttons/target/release
+          path: /home/runner/work/niri_window_buttons/niri_window_buttons/target/release/libniri_window_buttons.so
           retention-days: 45

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,6 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Build Module"]
-    types:
-      - completed
-    branches: [main]
 
 permissions:
   contents: write
@@ -21,20 +16,37 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - name: Checkout Repository
+      - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.87
           override: true
           components: rustfmt, clippy
 
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config libgtk-3-dev libglib2.0-dev
+          sudo apt-get install -y pkg-config libgtk-3-dev \
+          libglib2.0-dev libdbus-1-dev libxkbcommon-dev
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build with cargo
         run: cargo build --release
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: niri_window_buttons
+          path: /target/release
+          retention days: 45


### PR DESCRIPTION
- Uses [dtolnay/rust-toolchain@stable](https://github.com/dtolnay/rust-toolchain)
- Will run on commit pushes and manual workflow_dispatch
- Paths to ignore: MD files + jpg/png pictures
- Caching included, average action time: 2.5 mins

Feel free to comment or edit!